### PR TITLE
Extend to include purging from tables that have a different partition key prefix

### DIFF
--- a/Src/AzureTablePurger/AzureTablePurger.App/AzureTablePurger.App.csproj
+++ b/Src/AzureTablePurger/AzureTablePurger.App/AzureTablePurger.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>f21c130e-d067-4ec4-a6a5-1b7b81af9ef1</UserSecretsId>
   </PropertyGroup>
 

--- a/Src/AzureTablePurger/AzureTablePurger.App/Program.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.App/Program.cs
@@ -17,6 +17,7 @@ namespace AzureTablePurger.App
         private const string ConfigKeyTargetStorageAccountConnectionString = "TargetStorageAccountConnectionString";
         private const string ConfigKeyTargetTableName = "TargetTableName";
         private const string ConfigKeyPurgeRecordsOlderThanDays = "PurgeRecordsOlderThanDays";
+        private const string ConfigKeyPartitionKeyPrefix = "";
 
         private static ServiceProvider _serviceProvider;
         private static IConfigurationRoot _config;
@@ -39,7 +40,8 @@ namespace AzureTablePurger.App
                 {
                     TargetAccountConnectionString = _config[ConfigKeyTargetStorageAccountConnectionString],
                     TargetTableName = _config[ConfigKeyTargetTableName],
-                    PurgeRecordsOlderThanDays = int.Parse(_config[ConfigKeyPurgeRecordsOlderThanDays])
+                    PurgeRecordsOlderThanDays = int.Parse(_config[ConfigKeyPurgeRecordsOlderThanDays]),
+                    PartitionKeyPrefix = _config[ConfigKeyPartitionKeyPrefix]
                 };
 
                 var cts = new CancellationTokenSource();
@@ -62,7 +64,8 @@ namespace AzureTablePurger.App
             {
                 { "-account", ConfigKeyTargetStorageAccountConnectionString },
                 { "-table", ConfigKeyTargetTableName },
-                { "-days", ConfigKeyPurgeRecordsOlderThanDays }
+                { "-days", ConfigKeyPurgeRecordsOlderThanDays },
+                { "-partitionKeyPrefix", ConfigKeyPartitionKeyPrefix }
             };
 
             configBuilder.AddCommandLine(commandLineArgs, switchMapping);

--- a/Src/AzureTablePurger/AzureTablePurger.Services.Tests/TicksAscendingWithLeadingZeroPartitionKeyHandlerTest.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.Services.Tests/TicksAscendingWithLeadingZeroPartitionKeyHandlerTest.cs
@@ -24,7 +24,7 @@ namespace AzureTablePurger.Services.Tests
             // Arrange
 
             // Act
-            _target.ConvertPartitionKeyToDateTime(Guid.NewGuid().ToString());
+            _target.ConvertPartitionKeyToDateTime(Guid.NewGuid().ToString(), "");
 
             // Assert - handled by method attribute
         }
@@ -36,7 +36,7 @@ namespace AzureTablePurger.Services.Tests
             string upperBound = DateTime.Now.Ticks.ToString("D19");
 
             // Act
-            var query = _target.GetTableQuery(null, upperBound);
+            var query = _target.GetTableQuery(null, upperBound, "");
 
             // Assert
             Assert.AreEqual($"(PartitionKey ge '0') and (PartitionKey lt '{upperBound}')", query.FilterString);
@@ -51,7 +51,7 @@ namespace AzureTablePurger.Services.Tests
             string upperBound = DateTime.Now.Ticks.ToString("D19");
 
             // Act
-            var query = _target.GetTableQuery(lowerBound, upperBound);
+            var query = _target.GetTableQuery(lowerBound, upperBound, "");
 
             // Assert
             Assert.AreEqual($"(PartitionKey ge '{lowerBound}') and (PartitionKey lt '{upperBound}')", query.FilterString);
@@ -69,7 +69,7 @@ namespace AzureTablePurger.Services.Tests
             string firstPortionOfUpperBound = approxUpperBound.Substring(0, 6);
 
             // Act
-            var query = _target.GetTableQuery(days);
+            var query = _target.GetTableQuery(days, "");
 
             // Assert
             Assert.IsTrue(query.FilterString.Contains($"(PartitionKey ge '0') and (PartitionKey lt '{firstPortionOfUpperBound}"));

--- a/Src/AzureTablePurger/AzureTablePurger.Services/IPartitionKeyHandler.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.Services/IPartitionKeyHandler.cs
@@ -6,12 +6,12 @@ namespace AzureTablePurger.Services
 {
     public interface IPartitionKeyHandler
     {
-        TableQuery GetTableQuery(int purgeEntitiesOlderThanDays);
+        TableQuery GetTableQuery(int purgeEntitiesOlderThanDays, string partitionKeyPrefix = "");
 
-        DateTime ConvertPartitionKeyToDateTime(string partitionKey);
+        DateTime ConvertPartitionKeyToDateTime(string partitionKey, string partitionKeyPrefix);
 
         string GetPartitionKeyForDate(DateTime date);
 
-        TableQuery GetTableQuery(string lowerBoundPartitionKey, string upperBoundPartitionKey);
+        TableQuery GetTableQuery(string lowerBoundPartitionKey, string upperBoundPartitionKey, string partitionKeyPrefix);
     }
 }

--- a/Src/AzureTablePurger/AzureTablePurger.Services/PurgeEntitiesOptions.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.Services/PurgeEntitiesOptions.cs
@@ -7,5 +7,7 @@
         public string TargetTableName { get; set; }
 
         public int PurgeRecordsOlderThanDays { get; set; }
+
+        public string PartitionKeyPrefix { get; set; }
     }
 }

--- a/Src/AzureTablePurger/AzureTablePurger.Services/SimpleTablePurger.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.Services/SimpleTablePurger.cs
@@ -43,7 +43,7 @@ namespace AzureTablePurger.Services
 
             _logger.LogInformation($"TargetAccount={tableClient.StorageUri.PrimaryUri}, Table={table.Name}, PurgeRecordsOlderThanDays={options.PurgeRecordsOlderThanDays}");
 
-            var query = _partitionKeyHandler.GetTableQuery(options.PurgeRecordsOlderThanDays);
+            var query = _partitionKeyHandler.GetTableQuery(options.PurgeRecordsOlderThanDays, options.PartitionKeyPrefix);
             var continuationToken = new TableContinuationToken();
 
             int numPagesProcessed = 0;
@@ -64,7 +64,7 @@ namespace AzureTablePurger.Services
                     break;
                 }
 
-                var firstResultTimestamp = _partitionKeyHandler.ConvertPartitionKeyToDateTime(page.Results.First().PartitionKey);
+                var firstResultTimestamp = _partitionKeyHandler.ConvertPartitionKeyToDateTime(page.Results.First().PartitionKey, options.PartitionKeyPrefix);
                 _logger.LogInformation($"Page {pageNumber}: processing {page.Count()} results starting at timestamp {firstResultTimestamp}");
 
                 var partitionsFromPage = GetPartitionsFromPage(page.Results);

--- a/Src/AzureTablePurger/AzureTablePurger.Services/TicksAscendingWithLeadingZeroPartitionKeyHandler.cs
+++ b/Src/AzureTablePurger/AzureTablePurger.Services/TicksAscendingWithLeadingZeroPartitionKeyHandler.cs
@@ -14,26 +14,26 @@ namespace AzureTablePurger.Services
             _logger = logger;
         }
 
-        public TableQuery GetTableQuery(int purgeEntitiesOlderThanDays)
+        public TableQuery GetTableQuery(int purgeEntitiesOlderThanDays, string partitionKeyPrefix = "")
         {
             var maximumPartitionKeyToDelete = GetMaximumPartitionKeyToDelete(purgeEntitiesOlderThanDays);
 
-            return GetTableQuery(null, maximumPartitionKeyToDelete);
+            return GetTableQuery(null, maximumPartitionKeyToDelete, partitionKeyPrefix);
         }
 
-        public TableQuery GetTableQuery(string lowerBoundPartitionKey, string upperBoundPartitionKey)
+        public TableQuery GetTableQuery(string lowerBoundPartitionKey, string upperBoundPartitionKey, string partitionKeyPrefix)
         {
             if (string.IsNullOrEmpty(lowerBoundPartitionKey))
             {
                 lowerBoundPartitionKey = "0";
             }
 
-            var lowerBoundDateTime = ConvertPartitionKeyToDateTime(lowerBoundPartitionKey);
-            var upperBoundDateTime = ConvertPartitionKeyToDateTime(upperBoundPartitionKey);
+            var lowerBoundDateTime = ConvertPartitionKeyToDateTime(lowerBoundPartitionKey, partitionKeyPrefix);
+            var upperBoundDateTime = ConvertPartitionKeyToDateTime(upperBoundPartitionKey, partitionKeyPrefix);
             _logger.LogDebug($"Generating table query: lowerBound partitionKey={lowerBoundPartitionKey} ({lowerBoundDateTime}), upperBound partitionKey={upperBoundPartitionKey} ({upperBoundDateTime})");
 
-            var lowerBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, lowerBoundPartitionKey);
-            var upperBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, upperBoundPartitionKey);
+            var lowerBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.GreaterThanOrEqual, partitionKeyPrefix + lowerBoundPartitionKey);
+            var upperBound = TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.LessThan, partitionKeyPrefix + upperBoundPartitionKey);
             var combinedFilter = TableQuery.CombineFilters(lowerBound, TableOperators.And, upperBound);
 
             var query = new TableQuery()
@@ -43,9 +43,10 @@ namespace AzureTablePurger.Services
             return query;
         }
 
-        public DateTime ConvertPartitionKeyToDateTime(string partitionKey)
+        public DateTime ConvertPartitionKeyToDateTime(string partitionKey, string partitionKeyPrefix)
         {
-            var result = long.TryParse(partitionKey, out long ticks);
+            var toTryParse = (!string.IsNullOrEmpty(partitionKeyPrefix)) ? partitionKey.Replace(partitionKeyPrefix, "") : partitionKey;
+            var result = long.TryParse(toTryParse, out long ticks);
 
             if (!result)
             {


### PR DESCRIPTION
Greetings!

In our Azure environment where we have Linux VMs with diagnostics being collected, we found tables named `LinuxCpuVer2v0`, `LinuxDiskVer2v0`, `LinuxMemoryVer2v0` and `LinuxsyslogVer2v0`. 

AzureTablePurger failed to remove old rows from these tables because the partition keys are all prefixed with `0000000000000000000___`.

I have extended the utility to allow for a custom partition key prefix to be specified as a command line argument, and so far I've been able to recover over 2TB of storage using your utility to purge those tables.

Thank you for this work, I hope my contribution helps.